### PR TITLE
Try out sphinx-exercise for exercise formatting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,3 +60,6 @@ bibtex_bibfiles:
 sphinx:
   config:
     bibtex_reference_style: author_year # or label, super, \supercite
+  extra_extensions:
+    - sphinx_exercise
+    - sphinx_togglebutton

--- a/conda/environment-unpinned.yml
+++ b/conda/environment-unpinned.yml
@@ -21,6 +21,7 @@ dependencies:
   - hvplot
   - matplotlib-base
   - netcdf4
+  - pip
   - pint-xarray
   - pydap
   - python-graphviz
@@ -29,3 +30,5 @@ dependencies:
   - scipy
   - xarray
   - zarr
+  - pip:
+      - sphinx-exercise

--- a/fundamentals/02.3_aligning_data_objects.ipynb
+++ b/fundamentals/02.3_aligning_data_objects.ipynb
@@ -377,9 +377,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "**Exercise**  Consider the following two arrays. Write down the `x` and `y` coordinate locations for `da1 - da2`"
+    "```{exercise-start}\n",
+    ":label: exercise-alignment\n",
+    "\n",
+    "Consider the following two arrays. Write down the `x` and `y` coordinate locations for `da1 - da2\n",
+    "```"
    ]
   },
   {
@@ -403,12 +409,33 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "source": [
+    "```{exercise-end}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "hide-input"
     ]
    },
    "source": [
-    "**Answer** `x = [\"b\"], y=[0, 1, 2, 3]` . `da2` has been broadcasted to 2D  (so dimension \"y\" has been inserted) and the two arrays are aligned using `join=\"inner\"` prior to subtraction."
+    "```{solution} exercise-alignment\n",
+    ":label: solution-alignment\n",
+    ":class: dropdown\n",
+    "\n",
+    "`x = [\"b\"], y=[0, 1, 2, 3]` . `da2` has been broadcasted to 2D  (so dimension \"y\" has been inserted) and the two arrays are aligned using `join=\"inner\"` prior to subtraction.\n",
+    "```"
    ]
   },
   {
@@ -510,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/fundamentals/02.3_aligning_data_objects.ipynb
+++ b/fundamentals/02.3_aligning_data_objects.ipynb
@@ -384,7 +384,7 @@
     "```{exercise-start}\n",
     ":label: exercise-alignment\n",
     "\n",
-    "Consider the following two arrays. Write down the `x` and `y` coordinate locations for `da1 - da2\n",
+    "Consider the following two arrays. Write down the `x` and `y` coordinate locations for `da1 - da2`\n",
     "```"
    ]
   },
@@ -394,6 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This code cell is executed by jupyterbook\n",
     "da1 = xr.DataArray(\n",
     "    np.arange(12).reshape(3, 4),\n",
     "    dims=(\"x\", \"y\"),\n",
@@ -409,27 +410,14 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": []
-   },
-   "source": [
-    "```{exercise-end}\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
      "hide-input"
     ]
    },
    "source": [
+    "```{exercise-end}\n",
+    "```\n",
+    "\n",
     "```{solution} exercise-alignment\n",
     ":label: solution-alignment\n",
     ":class: dropdown\n",


### PR DESCRIPTION
https://ebp-sphinx-exercise.readthedocs.io/en/latest/ This allows nice formatting and referencing of exercises on the rendered website. I tested things out with https://tutorial.xarray.dev/fundamentals/02.3_aligning_data_objects.html#alignment-putting-data-on-the-same-grid

Unfortunately the more special myst and sphinx markup in .ipynb files can lead to somewhat odd appearance in JupyterLab. But I think requiring a bit of effort to reveal the solution is good to force thinking it through. Some screenshots below on how this looks unrendered and rendered: 

**Rendered:** Current (left) and This PR (right):
---
<img width="1270" alt="Screen Shot 2022-06-17 at 3 48 49 PM" src="https://user-images.githubusercontent.com/3924836/174410024-47d9bc85-480c-47be-84cc-ff2694fc8c29.png">


**Code:** What a user sees in JupyterLab (left), actual markdown (right) 
---
<img width="1323" alt="Screen Shot 2022-06-17 at 3 50 29 PM" src="https://user-images.githubusercontent.com/3924836/174410136-e856fd23-4c24-401e-a5a8-87969fa2f670.png">


If solutions don't require code execution (variables from earlier in a given notebook), they could be rendered on an entirely separate page (reference/exercise_solutions.md)...

A more lightweight solution is just to have separate mardown cells with headers (###solution) and use the 'hide-output' metadata tag to reveal on the website
